### PR TITLE
JWT Refresh token and Logout functionality

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,8 +31,8 @@
 		</dependency>
 
 		<dependency>
-			<groupId>org.postgresql</groupId>
-			<artifactId>postgresql</artifactId>
+			<groupId>com.mysql</groupId>
+			<artifactId>mysql-connector-j</artifactId>
 			<scope>runtime</scope>
 		</dependency>
 		<dependency>

--- a/src/main/java/com/alien/bank/management/system/controller/AuthenticationController.java
+++ b/src/main/java/com/alien/bank/management/system/controller/AuthenticationController.java
@@ -2,6 +2,7 @@ package com.alien.bank.management.system.controller;
 
 import com.alien.bank.management.system.model.ResponseModel;
 import com.alien.bank.management.system.model.authentication.LoginRequestModel;
+import com.alien.bank.management.system.model.authentication.RefreshTokenRequest;
 import com.alien.bank.management.system.model.authentication.RegisterRequestModel;
 import com.alien.bank.management.system.service.AuthenticationService;
 import jakarta.validation.Valid;
@@ -39,5 +40,23 @@ public class AuthenticationController {
                         .data(authenticationService.login(request))
                         .build()
         );
+    }
+
+    @PostMapping("/refreshToken")
+    public ResponseEntity<ResponseModel> refreshToken(@Valid @RequestBody RefreshTokenRequest request) {
+        return ResponseEntity.ok(
+                ResponseModel
+                        .builder()
+                        .status(HttpStatus.OK)
+                        .success(true)
+                        .data(authenticationService.refreshToken(request.getToken()))
+                        .build()
+        );
+    }
+
+    @PostMapping("/logout")
+    public ResponseEntity<Void> logout(@Valid @RequestBody RefreshTokenRequest refreshTokenDto) {
+        authenticationService.logout(refreshTokenDto.getToken());
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/alien/bank/management/system/entity/RefreshToken.java
+++ b/src/main/java/com/alien/bank/management/system/entity/RefreshToken.java
@@ -1,0 +1,30 @@
+package com.alien.bank.management.system.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.Instant;
+import java.util.Date;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class RefreshToken {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true)
+    private String token;
+
+    @Column(nullable = false)
+    private String username;
+
+    @Column(nullable = false)
+    private Instant expiryDate;
+
+}

--- a/src/main/java/com/alien/bank/management/system/exception/LowBalanceException.java
+++ b/src/main/java/com/alien/bank/management/system/exception/LowBalanceException.java
@@ -1,9 +1,6 @@
 package com.alien.bank.management.system.exception;
 
 public class LowBalanceException extends RuntimeException {
-    public LowBalanceException() {
-        super();
-    }
 
     public LowBalanceException(String message) {
         super(message);

--- a/src/main/java/com/alien/bank/management/system/exception/RefreshTokenNotValidException.java
+++ b/src/main/java/com/alien/bank/management/system/exception/RefreshTokenNotValidException.java
@@ -1,0 +1,7 @@
+package com.alien.bank.management.system.exception;
+
+public class RefreshTokenNotValidException extends RuntimeException {
+    public RefreshTokenNotValidException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/alien/bank/management/system/model/authentication/RefreshTokenRequest.java
+++ b/src/main/java/com/alien/bank/management/system/model/authentication/RefreshTokenRequest.java
@@ -1,15 +1,13 @@
 package com.alien.bank.management.system.model.authentication;
 
+
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
 @Data
-@Builder
 @AllArgsConstructor
 @NoArgsConstructor
-public class AuthenticationResponseModel {
+public class RefreshTokenRequest {
     private String token;
-    private String refreshToken;
 }

--- a/src/main/java/com/alien/bank/management/system/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/alien/bank/management/system/repository/RefreshTokenRepository.java
@@ -1,0 +1,14 @@
+package com.alien.bank.management.system.repository;
+
+import com.alien.bank.management.system.entity.RefreshToken;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Integer> {
+    Optional<RefreshToken> findByToken(String token);
+    Optional<RefreshToken> findByUsername(String username);
+    void deleteByUsername(String username);
+}

--- a/src/main/java/com/alien/bank/management/system/security/JwtService.java
+++ b/src/main/java/com/alien/bank/management/system/security/JwtService.java
@@ -12,10 +12,13 @@ import java.security.Key;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.UUID;
 import java.util.function.Function;
 
 @Service
 public class JwtService {
+
+    private static final long refreshTokenExpirationDate = 3600000;
 
     private static final String SECRET_KEY = "4bf04870a95e3897a02f95eb5477afd89400154cbab8e1f596897f8608572552";
 
@@ -39,6 +42,19 @@ public class JwtService {
                 .setSubject(userDetails.getUsername())
                 .setIssuedAt(new Date(System.currentTimeMillis()))
                 .setExpiration(new Date(System.currentTimeMillis() + 100000 * 60 * 24 ))
+                .signWith(getSignInKey(), SignatureAlgorithm.HS256)
+                .compact();
+    }
+
+    public String generateRefreshToken(String username) {
+        Date currentDate = new Date();
+        Date expireDate = new Date(currentDate.getTime() + refreshTokenExpirationDate);
+
+        return Jwts.builder()
+                .setSubject(username)
+                .setId(UUID.randomUUID().toString())
+                .setIssuedAt(currentDate)
+                .setExpiration(expireDate)
                 .signWith(getSignInKey(), SignatureAlgorithm.HS256)
                 .compact();
     }

--- a/src/main/java/com/alien/bank/management/system/service/AuthenticationService.java
+++ b/src/main/java/com/alien/bank/management/system/service/AuthenticationService.java
@@ -9,4 +9,7 @@ public interface AuthenticationService {
     public AuthenticationResponseModel register(RegisterRequestModel request);
 
     public AuthenticationResponseModel login(LoginRequestModel request);
+    AuthenticationResponseModel refreshToken(String refreshToken);
+
+    void logout(String refreshToken);
 }

--- a/src/main/java/com/alien/bank/management/system/service/RefreshTokenService.java
+++ b/src/main/java/com/alien/bank/management/system/service/RefreshTokenService.java
@@ -1,0 +1,13 @@
+package com.alien.bank.management.system.service;
+
+import com.alien.bank.management.system.entity.RefreshToken;
+
+import java.util.Optional;
+
+public interface RefreshTokenService {
+
+    String createRefreshToken(String username);
+    Optional<RefreshToken> findByToken(String token);
+    RefreshToken verifyExpiration(RefreshToken token);
+    void deleteByUsername(String username);
+}

--- a/src/main/java/com/alien/bank/management/system/service/impl/AuthenticationServiceImpl.java
+++ b/src/main/java/com/alien/bank/management/system/service/impl/AuthenticationServiceImpl.java
@@ -1,6 +1,8 @@
 package com.alien.bank.management.system.service.impl;
 
+import com.alien.bank.management.system.entity.RefreshToken;
 import com.alien.bank.management.system.entity.User;
+import com.alien.bank.management.system.exception.RefreshTokenNotValidException;
 import com.alien.bank.management.system.mapper.UserMapper;
 import com.alien.bank.management.system.model.authentication.AuthenticationResponseModel;
 import com.alien.bank.management.system.model.authentication.LoginRequestModel;
@@ -8,12 +10,17 @@ import com.alien.bank.management.system.model.authentication.RegisterRequestMode
 import com.alien.bank.management.system.repository.UserRepository;
 import com.alien.bank.management.system.security.JwtService;
 import com.alien.bank.management.system.service.AuthenticationService;
+import com.alien.bank.management.system.service.RefreshTokenService;
 import jakarta.persistence.EntityExistsException;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
+
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -23,6 +30,7 @@ public class AuthenticationServiceImpl implements AuthenticationService {
     private final JwtService jwtService;
     private final UserMapper userMapper;
     private final AuthenticationManager authenticationManager;
+    private final RefreshTokenService refreshTokenService;
 
 
     @Override
@@ -38,22 +46,55 @@ public class AuthenticationServiceImpl implements AuthenticationService {
 
     @Override
     public AuthenticationResponseModel login(LoginRequestModel request) {
-        authenticationManager.authenticate(
-                new UsernamePasswordAuthenticationToken(
-                        request.getEmail(),
-                        request.getPassword()
-                )
-        );
+        Authentication authentication = authenticationManager.authenticate(
+                new UsernamePasswordAuthenticationToken(request.getEmail(), request.getPassword()));
+
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+
+        String username = authentication.getName();
 
         var user = userRepository.findByEmail(request.getEmail())
                 .orElseThrow(() -> new EntityNotFoundException("User " + request.getEmail() + " Not Found"));
-
+        String refreshToken = refreshTokenService.createRefreshToken(username);
         return AuthenticationResponseModel
                 .builder()
                 .token(jwtService.generateToken(user))
+                .refreshToken(refreshToken)
                 .build();
     }
 
+
+    @Override
+    public AuthenticationResponseModel refreshToken(String refreshToken) {
+        Optional<RefreshToken> refreshTokenOptional = refreshTokenService.findByToken(refreshToken);
+
+        if (refreshTokenOptional.isEmpty()) {
+            throw new EntityNotFoundException("Refresh token not in database");
+        }
+
+        RefreshToken token = refreshTokenOptional.get();
+
+        try {
+            token = refreshTokenService.verifyExpiration(token);
+        } catch (RuntimeException e) {
+            throw new RefreshTokenNotValidException("Refresh token was expired. Please make a new signin request");
+        }
+
+        String username = token.getUsername();
+        String newAccessToken = jwtService.generateRefreshToken(username);
+
+        return AuthenticationResponseModel
+                .builder()
+                .token(newAccessToken)
+                .refreshToken(refreshToken)
+                .build();
+    }
+
+    @Override
+    public void logout(String refreshToken) {
+        refreshTokenService.findByToken(refreshToken)
+                .ifPresent(token -> refreshTokenService.deleteByUsername(token.getUsername()));
+    }
     private boolean isEmailOrPhoneAlreadyExists(String email, String phone) {
         return userRepository.existsByEmail(email) || userRepository.existsByPhone(phone);
     }

--- a/src/main/java/com/alien/bank/management/system/service/impl/RefreshTokenServiceImpl.java
+++ b/src/main/java/com/alien/bank/management/system/service/impl/RefreshTokenServiceImpl.java
@@ -1,0 +1,48 @@
+package com.alien.bank.management.system.service.impl;
+
+import com.alien.bank.management.system.entity.RefreshToken;
+import com.alien.bank.management.system.repository.RefreshTokenRepository;
+import com.alien.bank.management.system.service.RefreshTokenService;
+import jakarta.transaction.Transactional;
+import lombok.AllArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.Instant;
+import java.util.Optional;
+import java.util.UUID;
+
+@Service
+@AllArgsConstructor
+public class RefreshTokenServiceImpl implements RefreshTokenService {
+
+    private RefreshTokenRepository refreshTokenRepository;
+
+    public String createRefreshToken(String username) {
+        RefreshToken refreshToken = new RefreshToken();
+
+        refreshToken.setUsername(username);
+        refreshToken.setExpiryDate(Instant.now().plusMillis(3600000));
+        refreshToken.setToken(UUID.randomUUID().toString());
+
+        refreshToken = refreshTokenRepository.save(refreshToken);
+        return refreshToken.getToken();
+    }
+
+    public Optional<RefreshToken> findByToken(String token) {
+        return refreshTokenRepository.findByToken(token);
+    }
+
+    public RefreshToken verifyExpiration(RefreshToken token) {
+        if (token.getExpiryDate().compareTo(Instant.now()) < 0) {
+            refreshTokenRepository.delete(token);
+            throw new RuntimeException("Refresh token was expired. Please make a new signin request");
+        }
+
+        return token;
+    }
+
+    @Transactional
+    public void deleteByUsername(String username) {
+        refreshTokenRepository.deleteByUsername(username);
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,6 +1,6 @@
 spring.datasource.url=jdbc:mysql://localhost:3306/bank_app
-spring.datasource.username=root
-spring.datasource.password=Wababe8843
+spring.datasource.username=
+spring.datasource.password=
 
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQLDialect
 spring.jpa.hibernate.ddl-auto=update

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,10 +1,8 @@
-spring.datasource.url=jdbc:postgresql://dpg-cjhshp5mrchc73asugh0-a.frankfurt-postgres.render.com/bankms
-spring.datasource.username=bankms_user
-spring.datasource.password=HL3l7cd9fmAVsPYhUzO9hq0jUjxuOg7R
+spring.datasource.url=jdbc:mysql://localhost:3306/bank_app
+spring.datasource.username=root
+spring.datasource.password=Wababe8843
 
-spring.jpa.show-sql=true
-spring.jpa.properties.hibernate.format_sql=true
+spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQLDialect
 spring.jpa.hibernate.ddl-auto=update
-spring.jpa.properties.hibernate.dialect = org.hibernate.dialect.PostgreSQLDialect
 
 server.tomcat.accesslog.enabled=true

--- a/src/test/java/com/alien/bank/management/system/service/impl/AuthenticationServiceImplTest.java
+++ b/src/test/java/com/alien/bank/management/system/service/impl/AuthenticationServiceImplTest.java
@@ -8,6 +8,7 @@ import com.alien.bank.management.system.model.authentication.LoginRequestModel;
 import com.alien.bank.management.system.model.authentication.RegisterRequestModel;
 import com.alien.bank.management.system.repository.UserRepository;
 import com.alien.bank.management.system.security.JwtService;
+import com.alien.bank.management.system.service.RefreshTokenService;
 import jakarta.persistence.EntityExistsException;
 import jakarta.persistence.EntityNotFoundException;
 import org.junit.jupiter.api.BeforeEach;
@@ -47,12 +48,14 @@ public class AuthenticationServiceImplTest {
     private User user;
     private RegisterRequestModel registerRequest;
     private LoginRequestModel loginRequest;
+    @Mock
+    private RefreshTokenService refreshTokenService;
 
     @BeforeEach
     public void setUp() {
         MockitoAnnotations.openMocks(this);
 
-        authenticationService = new AuthenticationServiceImpl(userRepository, jwtService, userMapper, authenticationManager);
+        authenticationService = new AuthenticationServiceImpl(userRepository, jwtService, userMapper, authenticationManager, refreshTokenService);
 
         registerRequest = RegisterRequestModel
                 .builder()


### PR DESCRIPTION
This Pull Request introduces the implementation of JWT refresh token and logout functionality to enhance the authentication and security mechanisms in our application.

NB:/ - Used mysql database to store refreshtokens
Changes Made:

    JWT Refresh Token Functionality:
        Implemented a method to generate refresh tokens.
        Added an endpoint to handle refresh token requests.
        Integrated logic to verify the validity and expiration of refresh tokens.
        Updated the authentication flow to include issuing and validating refresh tokens.

    Logout Functionality:
        Added an endpoint to handle user logout requests.
        Implemented logic to delete refresh tokens upon logout to ensure invalidation of session.

Implementation Details:

    AuthenticationController.java:
        Added /refresh endpoint for generating new access tokens using refresh tokens.
        Added /logout endpoint for handling logout requests.

    AuthenticationService.java:
        Moved business logic for login, token refresh, and logout from the controller to the service layer.
        Implemented methods to generate refresh tokens, validate them, and handle logout logic.

    JwtService.java:
        Added method generateRefreshToken(String username) to create refresh tokens.
        Ensured proper signing and expiration logic for refresh tokens.

    RefreshTokenService.java:
        Created service methods to find, verify, and delete refresh tokens.